### PR TITLE
Fix XPath escaping for label-based clicks

### DIFF
--- a/src/common/actions.ts
+++ b/src/common/actions.ts
@@ -1,4 +1,5 @@
 // Helpers the content script can perform in the page
+import { escapeForXPath } from "./xpath";
 
 export function scroll(direction: "up" | "down", amount = 0.8) {
   window.scrollBy({
@@ -20,10 +21,11 @@ export function extractText(): string {
 }
 
 export function clickByLabel(label: string): boolean {
+  const normalizedLabel = label.toLowerCase();
   const xp = `//*[self::button or self::a or self::input or self::span]
               [contains(translate(normalize-space(.),
               'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),
-              '${label.toLowerCase()}')]`;
+              '${escapeForXPath(normalizedLabel)}')]`;
   const el = document.evaluate(
     xp, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null
   ).singleNodeValue as HTMLElement | null;

--- a/src/common/xpath.ts
+++ b/src/common/xpath.ts
@@ -1,0 +1,3 @@
+export function escapeForXPath(value: string): string {
+  return value.replace(/'/g, `', "'", '`);
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,4 +1,8 @@
 // src/content/index.ts
+import { escapeForXPath } from "../common/xpath";
+
+export { escapeForXPath } from "../common/xpath";
+
 // Define message interface for content script communication
 interface ContentScriptMessage {
   type?: "PING" | "SCROLL" | "OPEN_URL" | "SEARCH_WEB" | "SUMMARY" | "CLICK_LABEL" | "FILL_FIELD";
@@ -65,10 +69,11 @@ chrome.runtime.onMessage.addListener(
     }
 
     if (req.type === "CLICK_LABEL" && req.label) {
+      const normalizedLabel = req.label.toLowerCase();
       const xp = `//*[self::button or self::a or self::input or self::span]
                   [contains(translate(normalize-space(.),
                   'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),
-                  '${req.label.toLowerCase()}')]`;
+                  '${escapeForXPath(normalizedLabel)}')]`;
       const el = document.evaluate(
         xp, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null
       ).singleNodeValue as HTMLElement | null;


### PR DESCRIPTION
## Summary
- add a reusable escapeForXPath helper to normalize apostrophes for XPath
- update content and shared click helpers to use the escaped labels

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fb141e8218832182560432845e2917